### PR TITLE
Fix broken reference links at bottom of template

### DIFF
--- a/templates/base.tmpl
+++ b/templates/base.tmpl
@@ -49,9 +49,9 @@
 		    <p class="text-muted">
 		    <small>
 		    Built using
-		    <a href="http://twitter.github.com/bootstrap/">Bootstrap</a>,
-		    <a href="http://fortawesome.github.com/Font-Awesome/">Font Awesome</a>, and
-		    <a href="http://www.python.org/">Python</a>.
+		    <a href="https://getbootstrap.com">Bootstrap</a>,
+		    <a href="https://fontawesome.com//">Font Awesome</a>, and
+		    <a href="https://www.python.org/">Python</a>.
 		    <br/>
 		    &copy; 2022 <a href="http://www.nd.edu">University of Notre Dame</a>
 		    </small>


### PR DESCRIPTION
The links to Bootstrap and Font Awesome were outdated and 404'd, so the new links lead to their current actual websites. Also, they are now HTTPS links.